### PR TITLE
Removed authentication for local access

### DIFF
--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -46,6 +46,8 @@
   <arg name="enable_authorization" default="false" doc="enable user authorization using rocon_authorization package"/>
   <arg name="secret_users_file" doc="location of the secret user file"/>
   <arg name="users_roles" doc="users roles file location"/>
+ 
+
 
   <group ns="concert">
     <!-- ****************************** Parameters ***************************** -->
@@ -119,6 +121,7 @@
     </group>
   </group>
 
+  <node name="rqt_console" pkg="rqt_console" type="rqt_console" />
   <!-- ****************************** Rosbridge ******************************** -->
   <group if="$(arg enable_rosbridge)">
     <group if="$(arg enable_proxy)">

--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -121,7 +121,6 @@
     </group>
   </group>
 
-  <node name="rqt_console" pkg="rqt_console" type="rqt_console" />
   <!-- ****************************** Rosbridge ******************************** -->
   <group if="$(arg enable_rosbridge)">
     <group if="$(arg enable_proxy)">
@@ -133,7 +132,6 @@
     <include file="$(find rosbridge_server)/launch/rosbridge_websocket.launch">
       <arg name="address"   value="$(arg rosbridge_address)"/>
       <arg name="port"   value="$(arg rosbridge_port)"/>
-      <arg name="authentication_methods" value="$(arg authentication_methods)"/>
     </include>
     <node pkg="web_video_server" type="web_video_server" name="web_video_server"/>
   </group>


### PR DESCRIPTION
Authentication is still unavailable for local access.
This will now configure the local rosbridge to start without authentication enabled
