### PR TITLE
Add video server parameters

### DIFF
--- a/concert_master/launch/concert_master.launch
+++ b/concert_master/launch/concert_master.launch
@@ -17,6 +17,8 @@
   <!-- Web Proxy -->
   <arg name="enable_proxy"   default="false"  doc="Connect to an Internet Proxy server" />
   <arg name="proxy_uri" if="$(arg enable_proxy)" doc="Full WebSockets URI for the Proxy server" />
+  <arg name="web_video_server_address" if="$(arg enable_proxy)" default="localhost" doc="Optional web video server address" />
+  <arg name="web_video_server_port" if="$(arg enable_proxy)"  default="8080" doc="Optional web video server port" />
 
   <!-- Zeroconf -->
   <arg name="disable_zeroconf"            default="false" doc="It is required process to configure both hub and gateway. Configures rocon_hub zeroconf param and gateway disable_conf param.(e.g docker does not support zeroconf properly"/>
@@ -125,7 +127,9 @@
   <group if="$(arg enable_rosbridge)">
     <group if="$(arg enable_proxy)">
       <include file="$(find rosbridge_server)/launch/rosbridge_websocket_client.launch" >
-        <arg name="webserver_uri"   value="$(arg proxy_uri)"/>
+        <arg name="web_video_server_address" value="$(arg web_video_server_address)" />
+        <arg name="web_video_server_port" value="$(arg web_video_server_port)" />
+        <arg name="proxy_uri" value="$(arg proxy_uri)"/>
         <arg name="authentication_methods" value="$(arg authentication_methods)"/>
       </include>
     </group>


### PR DESCRIPTION
Required for web video server identification in rosbridge websocket
client. It also includes change of the name of webserver_uri to
proxy_uri
